### PR TITLE
[CONFIG] Increase test timeout to 10s

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---timeout 5000
+--timeout 10000


### PR DESCRIPTION
Previously increased integration test timeout from 2s to 5s. This resulted in a much fewer failed tests due to timeouts, but the occasional one still happens.

Increasing to 10s should avoid all timeout issues, barring when the third-party site is down.